### PR TITLE
check if licenses field is actually an array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,17 +93,22 @@ class Report {
       return Array.prototype.concat.apply([], results);
     }).then(licenses => {
       return licenses.map(info => {
-        if (info.licenses.length > 0) {
-          info.licenses = info.licenses.map((license: any) => {
-            if (typeof license === 'string') {
-              return license;
-            }
-            if (license.type) {
-              return license.type;
-            }
-            return 'Unknown';
-          });
+        if (!Array.isArray(info.licenses)) {
+            info.licenses = ['Unknown']
         }
+        return info;
+      });
+    }).then(licenses => {
+      return licenses.map(info => {
+        info.licenses = info.licenses.map((license: any) => {
+          if (typeof license === 'string') {
+            return license;
+          }
+          if (license.type) {
+            return license.type;
+          }
+          return 'Unknown';
+        });
 
         return info;
       });


### PR DESCRIPTION
Steps to reproduce issue:
- go to any dependency's package.json
- add `licenses` field to it and set it as string, for example
```
"licenses": "MIT"
```
- run command

It will fail because after licenses are added, object is then extended with package.json values (and licenses field used to be valid field in package.json)

Solves #14

Cheers